### PR TITLE
Add a placeholder for the Cause section

### DIFF
--- a/src/screens/Dashboard/Dashboard.js
+++ b/src/screens/Dashboard/Dashboard.js
@@ -33,7 +33,18 @@ class Dashboard extends Component {
         super(props);
         this.state = {
             editProfile: false,
-            highlightedCause: null
+            highlightedCause: null,
+            loadingCauses: false,
+        };
+    }
+
+    componentDidUpdate(prevProps) {
+        // Typical usage (don't forget to compare props):
+        const previousUserWithoutCauses = (prevProps.user && !prevProps.user.Causes);
+        const userCurrentlyHasCauses = (this.props.user && this.props.user.Causes);
+
+        if (previousUserWithoutCauses && userCurrentlyHasCauses) {
+            this.setState({ loadingCauses: false });
         };
     }
 
@@ -96,6 +107,7 @@ class Dashboard extends Component {
         } = this.props;
 
         if (!Causes) getUserCauses(id);
+        if (!Causes) this.setState({ loadingCauses: true });
     }
 
     render() {
@@ -107,7 +119,11 @@ class Dashboard extends Component {
             causeSelected
         } = this.props;
 
-        const { highlightedCause, editProfile } = this.state;
+        const {
+            highlightedCause,
+            editProfile,
+            loadingCauses,
+        } = this.state;
 
         if (!user && userData) getUserData(userData.id);
         if (!user && !userData) history.push("/");
@@ -143,6 +159,7 @@ class Dashboard extends Component {
                         />
 
                         <InViewportUserCauses
+                            loading={loadingCauses}
                             causes={user.Causes}
                             causeSelected={causeSelected}
                             selectCauseToHighlight={this.selectCauseToHighlight}
@@ -183,17 +200,14 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = {
+    causeSelected,
     getUserData,
     getUserCauses,
     getUserDonations,
     getCauseList,
-    causeSelected,
-    loadTokenFromCookie
+    loadTokenFromCookie,
 };
 
 export default withRouter(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps
-    )(Dashboard)
+    connect(mapStateToProps, mapDispatchToProps)(Dashboard)
 );

--- a/src/screens/Dashboard/components/UserCauses/UserCauses.js
+++ b/src/screens/Dashboard/components/UserCauses/UserCauses.js
@@ -19,7 +19,7 @@ class UserCauses extends Component {
     const {
       causeSelected,
       selectCauseToHighlight,
-      highlightedCause
+      highlightedCause,
     } = this.props;
 
     return causes.map(cause => {
@@ -46,10 +46,10 @@ class UserCauses extends Component {
     });
   }
 
-  renderNoCauses = () => {
+  renderNoCauses = (text) => {
     return (
       <div className="no-causes">
-        Loading your Causes...
+        {text}
       </div>
     );
   }
@@ -57,15 +57,24 @@ class UserCauses extends Component {
   render() {
     const {
       causes,
+      loading,
     } = this.props;
+
+    const hasCauses = (causes && causes.length > 0);
 
     return (
       <div className="UserCauses">
         <Heading text={'Your Causes'} />
-        <Slider>
-          {!causes && this.renderNoCauses()}
-          {causes && causes.length && this.getUserCauses(causes)}
-        </Slider>
+
+
+        {!hasCauses && loading && this.renderNoCauses('Loading Your Causes...')}
+
+        {!hasCauses && !loading && this.renderNoCauses('You currently have no causes...')}
+
+        {hasCauses &&
+          <Slider>
+            {this.getUserCauses(causes)}
+          </Slider>}
       </div>
     );
   }


### PR DESCRIPTION
Keeps the DonorInfo component from getting in the viewport. Thus stopping the fetch call for donations from happening until the user actually scrolls down to it